### PR TITLE
連絡先情報の更新とお問い合わせ方法の改善

### DIFF
--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -30,7 +30,7 @@ export default function LegalPage() {
         },
         contact: {
           title: '連絡先',
-          value: 'メール：info@yuchi.info\n電話：042-445-0608\n※お問い合わせはメールでお願いいたします',
+          value: 'メール：info@yuchidata.com',
           icon: '📞'
         },
         services: {
@@ -76,7 +76,7 @@ export default function LegalPage() {
         },
         representative: {
           title: 'Representative',
-          value: 'Hisashi Senga',
+          value: 'Koh Senga',
           icon: '👨‍💼'
         },
         address: {
@@ -86,7 +86,7 @@ export default function LegalPage() {
         },
         contact: {
           title: 'Contact Information',
-          value: 'Email: info@yuchi.info\nPhone: 042-445-0608\n* Please contact us via email',
+          value: 'Email: info@yuchidata.com',
           icon: '📞'
         },
         services: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -76,16 +76,13 @@ export default function Home() {
         company: '販売業者:',
         representative: '代表責任者:',
         address: '所在地:',
-        email: 'メール:',
-        phone: '電話:'
+        email: 'メール:'
       },
       contactInfo: {
         company: '合同会社YUCHI',
         representative: '千賀　恒',
-        email: 'info@yuchi.info',
-        phone: '042-445-0608',
-        address: '〒188-0012 東京都西東京市南町３丁目１６番３号',
-        phoneNote: '※お問い合わせはメールでお願いいたします'
+        email: 'info@yuchidata.com',
+        address: '〒188-0012 東京都西東京市南町３丁目１６番３号'
       },
       bankTitle: '提携銀行',
       partnerBanks: ['三菱UFJ銀行', 'PayPay銀行'],
@@ -109,16 +106,13 @@ export default function Home() {
         company: 'Company:',
         representative: 'Representative:',
         address: 'Address:',
-        email: 'Email:',
-        phone: 'Phone:'
+        email: 'Email:'
       },
       contactInfo: {
         company: 'Yuchi LLC',
-        representative: 'Hisashi Senga',
-        email: 'info@yuchi.info',
-        phone: '042-445-0608',
-        address: '3-16-3 Minami-cho, Nishitokyo City, Tokyo 188-0012, Japan',
-        phoneNote: '* Please contact us via email'
+        representative: 'Koh Senga',
+        email: 'info@yuchidata.com',
+        address: '3-16-3 Minami-cho, Nishitokyo City, Tokyo 188-0012, Japan'
       },
       bankTitle: 'PARTNER BANKS',
       partnerBanks: ['MUFG Bank', 'PayPay Bank'],
@@ -330,13 +324,6 @@ export default function Home() {
                         {t.contactInfo.email}
                       </a>
                     </div>
-                  </div>
-                  <div>
-                    <strong className="text-green-300">{t.contactLabels.phone}</strong>
-                    <div className="text-white/90 mt-1">{t.contactInfo.phone}</div>
-                  </div>
-                  <div className="text-white/60 italic">
-                    {t.contactInfo.phoneNote}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
- 電話番号を削除し、メール問い合わせに統一
- メールアドレスをinfo@yuchidata.comに変更
- 英語版代表者名をKoh Sengaに更新
- 日本語版・英語版・法的表記ページで統一
